### PR TITLE
Implement Calculate Magnetic Force + Extend NormalizeAndScale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "prettier": "^3.3.3",
         "typescript": "~5.6.0",
         "vite": "^5.4.10",
-        "vitest": "^2.1.3",
+        "vitest": "^2.1.8",
         "vue-tsc": "^2.1.6"
       }
     },
@@ -1321,14 +1321,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
-      "integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.4",
-        "@vitest/utils": "2.1.4",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
         "chai": "^5.1.2",
         "tinyrainbow": "^1.2.0"
       },
@@ -1337,13 +1337,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
-      "integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.4",
+        "@vitest/spy": "2.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.12"
       },
@@ -1364,9 +1364,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
-      "integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1377,13 +1377,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
-      "integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.4",
+        "@vitest/utils": "2.1.8",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -1391,13 +1391,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
-      "integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.4",
+        "@vitest/pretty-format": "2.1.8",
         "magic-string": "^0.30.12",
         "pathe": "^1.1.2"
       },
@@ -1406,9 +1406,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
-      "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1419,13 +1419,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.4.tgz",
-      "integrity": "sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.4",
+        "@vitest/pretty-format": "2.1.8",
         "loupe": "^3.1.2",
         "tinyrainbow": "^1.2.0"
       },
@@ -2161,6 +2161,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3972,9 +3979,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4411,14 +4418,15 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
-      "integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
         "pathe": "^1.1.2",
         "vite": "^5.0.0"
       },
@@ -4433,31 +4441,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
-      "integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.4",
-        "@vitest/mocker": "2.1.4",
-        "@vitest/pretty-format": "^2.1.4",
-        "@vitest/runner": "2.1.4",
-        "@vitest/snapshot": "2.1.4",
-        "@vitest/spy": "2.1.4",
-        "@vitest/utils": "2.1.4",
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
         "chai": "^5.1.2",
         "debug": "^4.3.7",
         "expect-type": "^1.1.0",
         "magic-string": "^0.30.12",
         "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
+        "std-env": "^3.8.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.1",
         "tinypool": "^1.0.1",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.4",
+        "vite-node": "2.1.8",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -4472,8 +4480,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.4",
-        "@vitest/ui": "2.1.4",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "^3.3.3",
     "typescript": "~5.6.0",
     "vite": "^5.4.10",
-    "vitest": "^2.1.3",
+    "vitest": "^2.1.8",
     "vue-tsc": "^2.1.6"
   }
 }

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -40,11 +40,27 @@ export function calculateMagneticForce(
   };
 }
 
-// Normalize a vector and scale it
-export function normalizeAndScale(vector: { x: number; y: number }, scale: number) {
-    const magnitude = Math.sqrt(vector.x * vector.x + vector.y * vector.y);
-    return {
-        x: (vector.x / magnitude) * scale,
-        y: (vector.y / magnitude) * scale
-    };
+// Normalize a vector and scale it - works with 2D and 3D vectors
+export function normalizeAndScale(
+  vector: { x: number; y: number; z?: number },
+  scale: number
+): { x: number; y: number; z?: number } {
+  // Calculate the magnitude
+  const magnitude = Math.sqrt(
+    vector.x ** 2 + vector.y ** 2 + (vector.z ? vector.z ** 2 : 0)
+  );
+
+  // Handle zero vector case
+  if (magnitude === 0) {
+    return { x: 0, y: 0, z: vector.z !== undefined ? 0 : undefined };
+  }
+
+  // Normalize and scale the vector
+  return {
+    x: (vector.x / magnitude) * scale,
+    y: (vector.y / magnitude) * scale,
+    z: vector.z !== undefined ? (vector.z / magnitude) * scale : undefined,
+  };
 }
+
+

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -19,6 +19,27 @@ export function calculateElectricField(chargePosition: { x: number; y: number },
     return isPositive ? { x: fieldX, y: fieldY } : { x: -fieldX, y: -fieldY };
 }
 
+// Calculate the magnetic force vector on a moving point charge
+export function calculateMagneticForce(
+  chargeMagnitude: number,
+  chargeVelocity: { x: number; y: number; z: number },
+  magneticField: { x: number; y: number; z: number }
+): { x: number; y: number; z: number } {
+  // Cross product: v x B
+  const crossProduct = {
+    x: chargeVelocity.y * magneticField.z - chargeVelocity.z * magneticField.y,
+    y: chargeVelocity.z * magneticField.x - chargeVelocity.x * magneticField.z,
+    z: chargeVelocity.x * magneticField.y - chargeVelocity.y * magneticField.x,
+  };
+
+  // Scale by charge magnitude
+  return {
+    x: chargeMagnitude * crossProduct.x,
+    y: chargeMagnitude * crossProduct.y,
+    z: chargeMagnitude * crossProduct.z,
+  };
+}
+
 // Normalize a vector and scale it
 export function normalizeAndScale(vector: { x: number; y: number }, scale: number) {
     const magnitude = Math.sqrt(vector.x * vector.x + vector.y * vector.y);

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -1,5 +1,0 @@
-import { expect, test } from 'vitest';
-
-test('sample test', () => {
-  expect(true).toBe(true);
-});

--- a/tests/mathUtils.test.ts
+++ b/tests/mathUtils.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateElectricField,
+  calculateMagneticForce,
+  normalizeAndScale,
+} from '../src/utils/mathUtils'
+import { K } from '../src/consts/consts'
+
+describe('mathUtils', () => {
+  describe('calculateElectricField', () => {
+    it('calculates the electric field at a point due to a positive charge', () => {
+      const chargePosition = { x: 0, y: 0 }
+      const chargeMagnitude = 5
+      const point = { x: 3, y: 4 }
+      const isPositive = true
+
+      const result = calculateElectricField(
+        chargePosition,
+        chargeMagnitude,
+        point,
+        isPositive,
+      )
+
+      const rSquared = 3 ** 2 + 4 ** 2
+      const expectedMagnitude = (K * chargeMagnitude) / rSquared
+
+      expect(result.x).toBeCloseTo((expectedMagnitude * 3) / 5, 6)
+      expect(result.y).toBeCloseTo((expectedMagnitude * 4) / 5, 6)
+    })
+
+    it('calculates the electric field at a point due to a negative charge', () => {
+      const chargePosition = { x: 0, y: 0 }
+      const chargeMagnitude = 5
+      const point = { x: 3, y: 4 }
+      const isPositive = false
+
+      const result = calculateElectricField(
+        chargePosition,
+        chargeMagnitude,
+        point,
+        isPositive,
+      )
+
+      const rSquared = 3 ** 2 + 4 ** 2
+      const expectedMagnitude = (K * chargeMagnitude) / rSquared
+
+      expect(result.x).toBeCloseTo(-(expectedMagnitude * 3) / 5, 6)
+      expect(result.y).toBeCloseTo(-(expectedMagnitude * 4) / 5, 6)
+    })
+
+    it('returns {0, 0} when the point is at the charge position to avoid division by zero', () => {
+      const chargePosition = { x: 0, y: 0 }
+      const chargeMagnitude = 5
+      const point = { x: 0, y: 0 }
+      const isPositive = true
+
+      const result = calculateElectricField(
+        chargePosition,
+        chargeMagnitude,
+        point,
+        isPositive,
+      )
+
+      expect(result).toEqual({ x: 0, y: 0 })
+    })
+  })
+
+  describe('calculateMagneticForce', () => {
+    it('calculates the magnetic force vector correctly', () => {
+      const chargeMagnitude = 2
+      const chargeVelocity = { x: 1, y: 0, z: 0 }
+      const magneticField = { x: 0, y: 1, z: 0 }
+
+      const result = calculateMagneticForce(
+        chargeMagnitude,
+        chargeVelocity,
+        magneticField,
+      )
+
+      expect(result).toEqual({ x: 0, y: 0, z: 2 })
+    })
+
+    it('returns a zero vector when the charge velocity is zero', () => {
+      const chargeMagnitude = 5
+      const chargeVelocity = { x: 0, y: 0, z: 0 }
+      const magneticField = { x: 0, y: 1, z: 0 }
+
+      const result = calculateMagneticForce(
+        chargeMagnitude,
+        chargeVelocity,
+        magneticField,
+      )
+
+      expect(result).toEqual({ x: 0, y: 0, z: 0 })
+    })
+
+    it('returns a zero vector when the magnetic field is zero', () => {
+      const chargeMagnitude = 5
+      const chargeVelocity = { x: 1, y: 0, z: 0 }
+      const magneticField = { x: 0, y: 0, z: 0 }
+
+      const result = calculateMagneticForce(
+        chargeMagnitude,
+        chargeVelocity,
+        magneticField,
+      )
+
+      expect(result).toEqual({ x: 0, y: 0, z: 0 })
+    })
+  })
+
+  describe('normalizeAndScale', () => {
+    it('normalizes and scales a 2D non-zero vector correctly', () => {
+      const vector = { x: 3, y: 4 } // Magnitude: 5
+      const scale = 10
+
+      const result = normalizeAndScale(vector, scale)
+
+      expect(result).toEqual({
+        x: (3 / 5) * 10,
+        y: (4 / 5) * 10,
+      })
+    })
+
+    it('normalizes and scales a 3D non-zero vector correctly', () => {
+      const vector = { x: 1, y: 2, z: 2 } // Magnitude: sqrt(1^2 + 2^2 + 2^2) = 3
+      const scale = 6
+
+      const result = normalizeAndScale(vector, scale)
+
+      expect(result).toEqual({
+        x: (1 / 3) * 6,
+        y: (2 / 3) * 6,
+        z: (2 / 3) * 6,
+      })
+    })
+
+    it('returns {0, 0} for a 2D zero vector', () => {
+      const vector = { x: 0, y: 0 }
+      const scale = 10
+
+      const result = normalizeAndScale(vector, scale)
+
+      expect(result).toEqual({ x: 0, y: 0 })
+    })
+
+    it('returns {0, 0, 0} for a 3D zero vector', () => {
+      const vector = { x: 0, y: 0, z: 0 }
+      const scale = 10
+
+      const result = normalizeAndScale(vector, scale)
+
+      expect(result).toEqual({ x: 0, y: 0, z: 0 })
+    })
+  })
+})


### PR DESCRIPTION
# Implement `calculateMagneticForce` and Extend `normalizeAndScale` with Comprehensive Tests

## **Summary**
This PR introduces the following key updates:
- Implementation of the `calculateMagneticForce` utility for calculating the magnetic force on a point charge.
- Extension of the `normalizeAndScale` function to support 3D vectors while maintaining compatibility with 2D vectors.
- Comprehensive test coverage for all newly implemented and updated utilities.

---

## **Details**

### **1. `calculateMagneticForce` Implementation**
- Calculates the magnetic force vector using the formula:  
  F = qv x B
- Accepts 3D velocity (`v`) and magnetic field (`B`) vectors as inputs.
- Scales the resulting cross-product by the charge magnitude (`q`).
- Handles edge cases, including:
  - Zero velocity vector.
  - Zero magnetic field vector.

### **2. `normalizeAndScale` Extension**
- Added support for 3D vectors with an optional `z` component.
- Properly handles zero-length vectors to avoid `NaN` results.
- Ensures compatibility with 2D vectors.

### **3. Comprehensive Tests**
- Added tests for `calculateMagneticForce`:
  - Validates correct force calculation for non-zero velocity and magnetic field vectors.
  - Verifies zero output for edge cases (e.g., zero velocity or zero magnetic field).
- Added tests for `normalizeAndScale`:
  - Tests normalization and scaling for both 2D and 3D vectors.
  - Handles zero-length vectors gracefully.
- Improved `calculateElectricField` tests:
  - Addressed floating-point precision issues using `toBeCloseTo`.

---

## **Testing**
All tests have been executed using Vitest and pass successfully:
```bash
npm run test:unit
