### PR TITLE
fix dragging bug

### DIFF
--- a/src/stores/charges.ts
+++ b/src/stores/charges.ts
@@ -6,7 +6,7 @@ export interface Charge {
   magnitude: number // Strength of the charge (Q)
   polarity: 'positive' | 'negative' // Whether it's a positive or negative charge
   position: { x: number; y: number } // Position on the canvas
-  velocity: { x: number; y: number, z: number } // Velocity vector of the charge
+  velocity: { x: number; y: number; z: number } // Velocity vector of the charge
   force?: { x: number; y: number; z: number } // Optional: Magnetic force vector
 }
 
@@ -28,7 +28,7 @@ export const useChargesStore = defineStore('charges', {
         magnitude: charge.magnitude,
         polarity: charge.polarity,
         position: { x: 400, y: 300 }, // Place charge in center of canvas initially
-        velocity: { x: 0, y: 0, z:0 },
+        velocity: { x: 0, y: 0, z: 0 },
       }
       this.charges.push(newCharge)
     },


### PR DESCRIPTION
# **Fix Smooth Dragging for Charges**

## **Summary**
This PR addresses the issue where dragging a charge on the PixiCanvas would stop when the cursor moved outside the bounds of the object being dragged. The fix ensures smooth dragging by leveraging global pointer event listeners attached to the PixiJS stage.

---

## **Changes Made**
### **1. Implemented Global Pointer Event Handling**
- Added `pointermove` and `pointerup` event listeners at the **stage level** to ensure dragging continues even when the cursor moves beyond the bounds of the dragged object.
- Updated charge positions dynamically as the cursor moves.

### **2. Improved Canvas Resize Behavior**
- Ensured that charge graphics are re-rendered correctly when the canvas resizes.
- Added a call to `updateChargesOnCanvas` in the resize logic.

### **3. Minor Code Improvements**
- Fixed indentation and formatting inconsistencies in the `charges` store and `PixiCanvas.vue`.
- Simplified the event handler for `pointerup` to reset the `dragging` state for all charges.

---

## **Testing**
### **Manual Testing**
- Dragged charges across the canvas, ensuring smooth motion even when the cursor moved quickly or outside the charge's bounds.
- Verified that charges update their positions in the store correctly.
- Tested resizing the canvas to ensure charges and fields re-render appropriately.

### **Automated Tests**
- No new tests were added, as this functionality relies heavily on manual interaction with the UI.