### PR TITLE
Added toggle feature and clear canvas

### DIFF
--- a/src/stores/charges.ts
+++ b/src/stores/charges.ts
@@ -10,12 +10,16 @@ export interface Charge {
   force?: { x: number; y: number; z: number } // Optional: Magnetic force vector
 }
 
+// Add mode type
+export type SimulationMode = 'electric' | 'magnetic';
+
 // Create a Pinia store for managing charges
 export const useChargesStore = defineStore('charges', {
   // Initial state of the store
   state: () => ({
     charges: [] as Charge[], // Array to hold all charges in the simulation
     selectedChargeId: null as string | null,
+    mode: 'electric' as SimulationMode, // Add mode to state
   }),
 
   // Actions that can be performed on the store
@@ -53,7 +57,13 @@ export const useChargesStore = defineStore('charges', {
         if (updatedCharge.polarity !== undefined) {
           charge.polarity = updatedCharge.polarity
         }
+        if (updatedCharge.velocity !== undefined) {
+          charge.velocity = updatedCharge.velocity
+        }
       }
+    },
+    setMode(mode: SimulationMode) {
+      this.mode = mode;
     },
   },
 })


### PR DESCRIPTION
# Add Electric/Magnetic Mode Toggle

## Description
This PR adds the ability to toggle between electric and magnetic field visualization modes. Users can now switch between modes while maintaining charge positions and properties. In magnetic mode, users can specify velocity vectors for charges, preparing for future magnetic field visualization.

## Changes
- Added mode toggle in the control bar
- Implemented mode state management in the charges store
- Added velocity input fields for magnetic mode
- Updated charge creation/editing to handle velocity vectors
- Modified field visualization to respect current mode
- Ensured proper cleanup of field visualizations when switching modes

### Added
- `SimulationMode` type for tracking visualization mode
- Mode toggle UI component in ControlBar
- Velocity input fields (x, y, z components)
- Mode-specific field visualization logic

### Modified
- `ChargesStore`: Added mode state and related actions
- `PixiCanvas`: Updated field drawing logic to respect current mode
- `ControlBar`: Added mode toggle and velocity inputs
- Charge interface to include velocity vector

## Testing
- [x] Mode toggle switches correctly between electric and magnetic modes
- [x] Electric field lines only show in electric mode
- [x] Charge positions persist when switching modes
- [x] Velocity inputs appear only in magnetic mode
- [x] Field visualization clears properly when switching modes

## Notes
Seems like velocity inputs aren't persistent ( doesn't actually set the velocity) and need to add magnitude field for the velocity.