### PR TITLE
add Uniform Magnetic Field input to control bar

### DIFF
--- a/src/components/ControlBar.vue
+++ b/src/components/ControlBar.vue
@@ -98,6 +98,13 @@
             placeholder="e.g. 1.0 (Tesla)"
           />
         </div>
+
+        <div class="form-group">
+          <label>Magnetic Field Direction:</label>
+          <button @click="toggleMagneticFieldDirection" class="direction-toggle">
+            {{ magneticFieldDirection === 'out' ? '⬆ Out of Page' : '⬇ Into Page' }}
+          </button>
+        </div>
       </template>
 
       <div class="form-group">
@@ -172,16 +179,8 @@ const velocityMagnitude = ref('0');
 const velocityDirectionX = ref('0');
 const velocityDirectionY = ref('0');
 
-const magneticFieldValue = ref('0');
-
 // Add computed for current mode
 const mode = computed(() => chargesStore.mode);
-
-watch(magneticFieldValue, (newVal) => {
-  const parsed = parseFloat(newVal) || 0;
-  // For example, store along z-axis if you prefer
-  chargesStore.setMagneticField({ x: 0, y: 0, z: parsed });
-});
 
 // Computed properties
 const isValid = computed(() => {
@@ -211,6 +210,22 @@ watch(() => chargesStore.selectedChargeId, (newId) => {
     resetForm();
   }
 });
+
+// Magnetic Field State
+const magneticFieldValue = ref('0');
+const magneticFieldDirection = ref<'in' | 'out'>('out'); // Default: Out of the page
+
+// Watch for Magnetic Field Changes
+watch([magneticFieldValue, magneticFieldDirection], ([newValue, newDirection]) => {
+  const parsed = parseFloat(newValue) || 0;
+  const zComponent = newDirection === 'out' ? parsed : -parsed;
+  chargesStore.setMagneticField({ x: 0, y: 0, z: zComponent });
+});
+
+// Function to Toggle Magnetic Field Direction
+const toggleMagneticFieldDirection = () => {
+  magneticFieldDirection.value = magneticFieldDirection.value === 'out' ? 'in' : 'out';
+};
 
 // Handlers
 const handleAddCharge = () => {

--- a/src/components/ControlBar.vue
+++ b/src/components/ControlBar.vue
@@ -86,6 +86,18 @@
             </div>
           </div>
         </div>
+
+        <div class="form-group">
+          <label for="magField">Uniform Magnetic Field (T):</label>
+          <input
+            type="number"
+            id="magField"
+            v-model="magneticFieldValue"
+            step="0.1"
+            class="input-field"
+            placeholder="e.g. 1.0 (Tesla)"
+          />
+        </div>
       </template>
 
       <div class="form-group">
@@ -160,8 +172,16 @@ const velocityMagnitude = ref('0');
 const velocityDirectionX = ref('0');
 const velocityDirectionY = ref('0');
 
+const magneticFieldValue = ref('0');
+
 // Add computed for current mode
 const mode = computed(() => chargesStore.mode);
+
+watch(magneticFieldValue, (newVal) => {
+  const parsed = parseFloat(newVal) || 0;
+  // For example, store along z-axis if you prefer
+  chargesStore.setMagneticField({ x: 0, y: 0, z: parsed });
+});
 
 // Computed properties
 const isValid = computed(() => {

--- a/src/stores/charges.ts
+++ b/src/stores/charges.ts
@@ -22,7 +22,10 @@ export const useChargesStore = defineStore('charges', {
   state: () => ({
     charges: [] as Charge[], // Array to hold all charges in the simulation
     selectedChargeId: null as string | null,
-    mode: 'electric' as SimulationMode, // Add mode to state
+    mode: 'electric' as SimulationMode, // Simulation mode can be "electric" or "magnetic"
+
+    // Uniform magnetic field state (in Teslas, e.g. { x: 0, y: 0, z: 1 })
+    magneticField: { x: 0, y: 0, z: 0 },
   }),
 
   // Actions that can be performed on the store
@@ -34,7 +37,7 @@ export const useChargesStore = defineStore('charges', {
         id: crypto.randomUUID(), // Generate unique ID for the charge
         magnitude: charge.magnitude,
         polarity: charge.polarity,
-        position: { x: 400, y: 300 }, // Place charge in center of canvas initially
+        position: { x: 400, y: 300 }, // Place charge in the center of canvas initially
         velocity: {
           magnitude: 0,
           direction: { x: 0, y: 0 }
@@ -42,18 +45,26 @@ export const useChargesStore = defineStore('charges', {
       }
       this.charges.push(newCharge)
     },
+
+    // Remove charge by ID
     removeCharge(chargeId: string) {
       this.charges = this.charges.filter(charge => charge.id !== chargeId)
     },
+
+    // Update charge position by ID
     updateChargePosition(id: string, newPosition: { x: number; y: number }) {
       const charge = this.charges.find(c => c.id === id)
       if (charge) {
         charge.position = newPosition
       }
     },
+
+    // Set which charge is selected (for editing, highlighting, etc.)
     setSelectedCharge(id: string | null) {
       this.selectedChargeId = id
     },
+
+    // Update existing charge fields (magnitude, polarity, velocity, etc.)
     updateCharge(updatedCharge: Partial<Charge> & { id: string }) {
       const charge = this.charges.find(c => c.id === updatedCharge.id)
       if (charge) {
@@ -68,8 +79,15 @@ export const useChargesStore = defineStore('charges', {
         }
       }
     },
+
+    // Switch between "electric" or "magnetic" mode
     setMode(mode: SimulationMode) {
-      this.mode = mode;
+      this.mode = mode
+    },
+
+    // Set the uniform magnetic field (in Teslas)
+    setMagneticField(newField: { x: number; y: number; z: number }) {
+      this.magneticField = newField
     },
   },
 })


### PR DESCRIPTION
Closes #30 

This PR adds a uniform magnetic field visualization method `drawMagneticField` and updates the store so we can store the magnetic field value. The store now has:
- A new state property `magneticField: { x: number; y: number; z: number }`.
- A new action `setMagneticField(newField)` to allow components to set or update the field.

**Changes**  
- **`charges.ts`**: Introduced `magneticField` in the store’s state and a `setMagneticField` action.
