### PR TITLE
Draw Magnetic Force

### DIFF
--- a/src/components/ControlBar.vue
+++ b/src/components/ControlBar.vue
@@ -222,6 +222,33 @@ watch([magneticFieldValue, magneticFieldDirection], ([newValue, newDirection]) =
   chargesStore.setMagneticField({ x: 0, y: 0, z: zComponent });
 });
 
+watch([velocityMagnitude, velocityDirectionX, velocityDirectionY], () => {
+  if (!chargesStore.selectedChargeId) return;
+
+  const chargeId = chargesStore.selectedChargeId;
+  const charge = chargesStore.charges.find(c => c.id === chargeId);
+  if (!charge) return;
+
+  // Normalize direction vector
+  const dirX = parseFloat(velocityDirectionX.value) || 0;
+  const dirY = parseFloat(velocityDirectionY.value) || 0;
+  const magnitude = parseFloat(velocityMagnitude.value) || 0;
+  const length = Math.sqrt(dirX * dirX + dirY * dirY) || 1;
+
+  chargesStore.updateCharge({
+    id: chargeId,
+    velocity: {
+      magnitude: magnitude,
+      direction: {
+        x: (dirX / length) * magnitude,
+        y: (dirY / length) * magnitude,
+      }
+    }
+  });
+
+  console.log(`🚀 Updated charge ${chargeId} velocity:`, chargesStore.charges.find(c => c.id === chargeId)?.velocity);
+});
+
 // Function to Toggle Magnetic Field Direction
 const toggleMagneticFieldDirection = () => {
   magneticFieldDirection.value = magneticFieldDirection.value === 'out' ? 'in' : 'out';

--- a/src/components/PixiCanvas.vue
+++ b/src/components/PixiCanvas.vue
@@ -7,7 +7,7 @@ import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
 import * as PIXI from 'pixi.js';
 import type { Charge } from '@/stores/charges';
 import { useChargesStore} from '@/stores/charges';
-import { drawElectricField, drawMagneticField } from '@/utils/drawingUtils';
+import { drawElectricField, drawMagneticField, drawMagneticForcesOnAllCharges } from '@/utils/drawingUtils';
 
 const canvasContainer = ref<HTMLElement | null>(null);
 const chargesStore = useChargesStore();
@@ -138,7 +138,8 @@ onMounted(async () => {
       if (chargesStore.mode === 'electric') {
         drawElectricField(app!, newCharges);
       } else {
-        drawMagneticField(app!, chargesStore.magneticField)
+        drawMagneticField(app!, chargesStore.magneticField);
+        drawMagneticForcesOnAllCharges(app!, chargesStore);
       }
       updateChargesOnCanvas(newCharges);
     },
@@ -160,9 +161,9 @@ onMounted(async () => {
       if (newMode === 'electric') {
         drawElectricField(app, chargesStore.charges);
       } else {
-        drawMagneticField(app!, chargesStore.magneticField)
+        drawMagneticField(app!, chargesStore.magneticField);
+        drawMagneticForcesOnAllCharges(app!, chargesStore);
       }
-      // We'll implement magnetic field visualization later
     }
   );
 
@@ -173,6 +174,7 @@ onMounted(async () => {
       // Only draw electric field if in electric mode
       if (chargesStore.mode === 'magnetic') {
         drawMagneticField(app!, chargesStore.magneticField)
+        drawMagneticForcesOnAllCharges(app!, chargesStore);
       }
     },
     { deep: true, immediate: true }
@@ -199,6 +201,7 @@ const resize = () => {
       drawElectricField(app, chargesStore.charges);
     } else {
         drawMagneticField(app!, chargesStore.magneticField)
+        drawMagneticForcesOnAllCharges(app!, chargesStore);
       }
     updateChargesOnCanvas(chargesStore.charges)
   }

--- a/src/consts/consts.ts
+++ b/src/consts/consts.ts
@@ -6,3 +6,7 @@ export const FIELD_SPACING = 64; // Spacing between field vectors in pixels
 export const VECTOR_LENGTH_SCALE = 0.0005; // Scaling factor for vector length
 export const ARROWHEAD_LENGTH = 8; // Length of the arrowhead
 export const MAX_VECTOR_LENGTH = 30; // Maximum length for the vectors (to prevent too long arrows)
+export const MAG_FORCE_ARROW_FACTOR = 500000; // Scaling factor for drawing magnetic force arrows
+
+// Colors
+export const MAG_FORCE_ARROW_COLOUR = 0x6832a8;

--- a/src/stores/charges.ts
+++ b/src/stores/charges.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import type { Store } from 'pinia'
 
 // Define the structure of a charge object
 export interface Charge {
@@ -91,3 +92,9 @@ export const useChargesStore = defineStore('charges', {
     },
   },
 })
+
+export interface ChargesStore extends Store {
+  charges: Charge[];
+  magneticField: { x: number; y: number; z: number };
+}
+

--- a/src/utils/drawingUtils.ts
+++ b/src/utils/drawingUtils.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { calculateElectricField, calculateMagneticForce, normalizeAndScale } from './mathUtils';
 import type { Charge } from '@/stores/charges';
+import type { ChargesStore } from '@/stores/charges';
 import { FIELD_SPACING, VECTOR_LENGTH_SCALE, MAX_VECTOR_LENGTH, ARROWHEAD_LENGTH, MAG_FORCE_ARROW_COLOUR, MAG_FORCE_ARROW_FACTOR } from '../consts';
 
 export function drawElectricField(app: PIXI.Application, charges: Charge[]) {
@@ -173,7 +174,7 @@ export function drawMagneticField(app: PIXI.Application, magneticField: { x: num
     }
   }
 }
-export function drawMagneticForcesOnAllCharges(app, chargesStore) {
+export function drawMagneticForcesOnAllCharges(app: PIXI.Application, chargesStore: ChargesStore) {
   if (!app) {
     return
   }


### PR DESCRIPTION
# 🔀 PR: Implement Magnetic Force Vector Drawing & Customization

Closes #33. 

## 📌 Summary
This PR introduces **dynamic drawing of magnetic force vectors** (`q(v × B)`) in the simulation. Magnetic force arrows now:
- ✅ **Update in real-time** when charge velocity or magnetic field changes
- ✅ **Scale properly** for visibility and physics accuracy
- ✅ **Use a customizable arrow color and scaling factor**

![image](https://github.com/user-attachments/assets/c823615f-a156-4d96-b5d9-70c288d324da)

## ✨ Changes Implemented
- **Calls `drawMagneticForce` dynamically** for each charge
- **Ensures old force vectors are removed** before redrawing
- **Uses configurable settings**:
  - **Arrow color:** `0x6832a8` (purple)
  - **Arrow scale factor:** `MAG_FORCE_ARROW_FACTOR = 500000`
- **Fixes force normalization issues** to prevent zero-length vectors

## 🔄 Affected Files
- `drawingUtils.ts`: Implements `drawMagneticForce` and `drawMagneticForcesOnAllCharges`
- `PixiCanvas.vue`: Calls force drawing on charge/magnetic field updates
- `consts.ts`: Adds `MAG_FORCE_ARROW_COLOUR` and `MAG_FORCE_ARROW_FACTOR`

## 🚀 Next Steps
- Improve vector animation for smoother transitions  
- Adjust scaling dynamically based on field strength  

