### PR TITLE
Send charge back to original position, preanimation upon reset.

### DIFF
--- a/src/stores/charges.ts
+++ b/src/stores/charges.ts
@@ -12,6 +12,7 @@ export interface Charge {
     direction: { x: number; y: number }
   }
   force?: { x: number; y: number; z: number } // Optional: Magnetic force vector
+  preAnimationPosition?: { x: number; y: number } // position on canvas before animation starts
 }
 
 // Add mode type
@@ -93,13 +94,16 @@ export const useChargesStore = defineStore('charges', {
     },
 
     startAnimation() {
+      this.charges.forEach(charge => {
+        charge.preAnimationPosition = { x: charge.position.x, y: charge.position.y }
+      })
       this.isAnimating = true;
     },
 
     resetAnimation() {
       this.isAnimating = false;
       this.charges.forEach(charge => {
-        charge.position = { x: 400, y: 300 };
+        charge.position = { x: charge.preAnimationPosition?.x ?? 300, y: charge.preAnimationPosition?.y ?? 400 };
         charge.velocity = { magnitude: 0, direction: { x: 0, y: 0 } };
       });
     },


### PR DESCRIPTION
Added a new field to charge store that will preserve the original position of the charge before animation begins. Then, upon animation reset, we will set the charge's position to be the original position.