### PR TITLE
Remove old fields when we toggle between screens

### DIFF
--- a/src/components/PixiCanvas.vue
+++ b/src/components/PixiCanvas.vue
@@ -7,7 +7,7 @@ import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
 import * as PIXI from 'pixi.js';
 import type { Charge } from '@/stores/charges';
 import { useChargesStore } from '@/stores/charges';
-import { drawElectricField, drawMagneticField, drawMagneticForcesOnAllCharges } from '@/utils/drawingUtils';
+import { drawElectricField, drawMagneticField, drawMagneticForcesOnAllCharges, removeFields } from '@/utils/drawingUtils';
 import { calculateMagneticForce } from '@/utils/mathUtils';
 import { ANIMATION_SPEED, FORCE_SCALING } from '@/consts';
 
@@ -140,8 +140,10 @@ onMounted(async () => {
     () => chargesStore.charges,
     (newCharges) => {
       if (chargesStore.mode === 'electric') {
+        removeFields(app!);
         drawElectricField(app!, newCharges);
       } else {
+        removeFields(app!);
         drawMagneticField(app!, chargesStore.magneticField);
         drawMagneticForcesOnAllCharges(app!, chargesStore);
       }
@@ -160,8 +162,10 @@ onMounted(async () => {
         .forEach(child => app!.stage.removeChild(child));
 
       if (newMode === 'electric') {
+        removeFields(app!);
         drawElectricField(app, chargesStore.charges);
       } else {
+        removeFields(app!);
         drawMagneticField(app!, chargesStore.magneticField);
         drawMagneticForcesOnAllCharges(app!, chargesStore);
       }
@@ -172,6 +176,7 @@ onMounted(async () => {
     () => chargesStore.magneticField,
     () => {
       if (chargesStore.mode === 'magnetic') {
+        removeFields(app!);
         drawMagneticField(app!, chargesStore.magneticField)
         drawMagneticForcesOnAllCharges(app!, chargesStore);
       }
@@ -201,8 +206,10 @@ const resize = () => {
   if (app) {
     app.renderer.resize(window.innerWidth, window.innerHeight);
     if (chargesStore.mode === 'electric') {
+      removeFields(app!);
       drawElectricField(app, chargesStore.charges);
     } else {
+      removeFields(app!);
       drawMagneticField(app!, chargesStore.magneticField)
       drawMagneticForcesOnAllCharges(app!, chargesStore);
     }

--- a/src/utils/drawingUtils.ts
+++ b/src/utils/drawingUtils.ts
@@ -19,6 +19,15 @@ const MIN_ALPHA = 0.15
 const MAX_ALPHA = 1.0
 const LOG_SCALE_FACTOR = 2
 
+export function removeFields(app: PIXI.Application) {
+  app.stage.children
+    .filter(child => child.name === 'magneticFieldSymbol')
+    .forEach(child => app.stage.removeChild(child));
+  app.stage.children
+    .filter(child => child.name === 'fieldVector')
+    .forEach(child => app.stage.removeChild(child));
+}
+
 export function drawElectricField(app: PIXI.Application, charges: Charge[]) {
   app.stage.children
     .filter(child => child.name === 'fieldVector')


### PR DESCRIPTION
Previously, when we moved between electric and magnetic fields, the older field would be left on the screen creating a disgusting visual to the user.
![Screenshot from 2025-03-19 19-50-17](https://github.com/user-attachments/assets/2ed424d0-1f54-4dc3-a7d3-d4e51bb26e52)

Now, with this change, the old field is removed before the new one is drawn.

https://github.com/user-attachments/assets/7cd260fb-9d95-45e5-b468-88af4d1cdafb



