### PR TITLE
Now force label is removed before redrawn.

### DIFF
--- a/src/utils/drawingUtils.ts
+++ b/src/utils/drawingUtils.ts
@@ -175,7 +175,7 @@ export function drawMagneticForce(
     fontWeight: "bold",
   });
 
-  forceLabel.name = `forceVector-label-${charge.id}`;
+  forceLabel.name = `magneticForceVector-label-${charge.id}`;
 
   // Position the label slightly offset from the arrow tip
   forceLabel.x = endX + 10; // Offset for better visibility


### PR DESCRIPTION
Had a glitch that i created because i wasn't removing the force vector label upon charge movement. No it has been fixed.