### PR TITLE
remove velocity arrow

### DIFF
--- a/src/components/PixiCanvas.vue
+++ b/src/components/PixiCanvas.vue
@@ -159,7 +159,7 @@ onMounted(async () => {
     (newMode) => {
       if (!app) return;
       app.stage.children
-        .filter(child => child.name === 'fieldVector' || child.name.startsWith('magneticForceVector-'))
+        .filter(child => child.name === 'fieldVector' || child.name.startsWith('magneticForceVector-') || child.name.startsWith('velocityVector-'))
         .forEach(child => app!.stage.removeChild(child));
 
       if (newMode === 'electric') {


### PR DESCRIPTION
After velocity arrow and force arrow were added each charge in the magnetic mode, toggling the mode back to electric mode only removes the force arrow.
<img width="1635" alt="Screenshot 2025-03-20 at 2 14 47 PM" src="https://github.com/user-attachments/assets/fe0d7b0f-0e38-4176-99b2-987713af1035" />
