### PR TITLE
Real-time Field Value Readouts at Cursor

### DIFF
--- a/src/components/PixiCanvas.vue
+++ b/src/components/PixiCanvas.vue
@@ -1,7 +1,8 @@
 <template>
-  <div ref="canvasContainer" style="width: 100%; height: 100%;" class="canvas-container"></div>
+    <div ref="canvasContainer" style="width: 100%; height: 100%;" class="canvas-container">
+      <div class="field-readout">{{ fieldReadout }}</div>
+    </div>
 </template>
-
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
 import * as PIXI from 'pixi.js';
@@ -12,7 +13,6 @@ import { calculateMagneticForce } from '@/utils/mathUtils';
 import { ANIMATION_SPEED, FORCE_SCALING } from '@/consts';
 import { getNetElectricFieldAtPoint } from '@/utils/mathUtils'
 
-const canvasRef = ref<HTMLDivElement | null>(null);
 const fieldReadout = ref('');
 const canvasContainer = ref<HTMLElement | null>(null);
 const chargesStore = useChargesStore();
@@ -24,7 +24,7 @@ let app: PIXI.Application | null = null;
 const MOVEMENT_STEP = 10; // pixels per keypress
 
 function handleMouseMove(event: MouseEvent) {
-  const rect = canvasRef.value?.getBoundingClientRect()
+  const rect = canvasContainer.value?.getBoundingClientRect()
   if (!rect) return
 
   const x = event.clientX - rect.left
@@ -32,7 +32,7 @@ function handleMouseMove(event: MouseEvent) {
 
   const field = getNetElectricFieldAtPoint({ x, y })
 
-  fieldReadout.value = `Ex: ${field.x.toFixed(2)}, Ey: ${field.y.toFixed(2)}`
+  fieldReadout.value = `Ex: ${(field.x / 1e3).toFixed(2)} kN/C, Ey: ${(-1 * field.y / 1e3).toFixed(2)} kN/C`
 }
 
 const handleKeyDown = (event: KeyboardEvent) => {
@@ -108,7 +108,7 @@ onMounted(async () => {
     height: window.innerHeight
   });
 
-  canvasRef.value?.addEventListener('mousemove', handleMouseMove);
+  canvasContainer.value?.addEventListener('mousemove', handleMouseMove);
 
   // Enable zIndex sorting so that graphics with higher zIndex render on top
   app.stage.sortableChildren = true;
@@ -213,7 +213,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  canvasRef.value?.removeEventListener('mousemove', handleMouseMove);
+  canvasContainer.value?.removeEventListener('mousemove', handleMouseMove);
   cancelAnimationFrame(animationFrameId);
 
   if (app) {
@@ -322,8 +322,23 @@ const updateChargesOnCanvas = (charges: Charge[]) => {
 
 <style scoped>
 .canvas-container {
-  flex-grow: 1;
+  position: relative;
+  width: 100%;
   height: 100%;
+  flex-grow: 1;
   overflow: hidden;
+}
+
+.field-readout {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 14px;
+  font-family: monospace;
+  border-radius: 4px;
+  pointer-events: none;
 }
 </style>

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,4 +1,5 @@
 import type { Charge } from '@/stores/charges'
+import { useChargesStore } from '@/stores/charges'
 import { K } from '../consts'
 
 // Calculate electric field at a given point due to a charge
@@ -71,4 +72,25 @@ export function normalizeAndScale(
     y: (vector.y / magnitude) * scale,
     z: vector.z !== undefined ? (vector.z / magnitude) * scale : undefined,
   }
+}
+
+export function getNetElectricFieldAtPoint(point: { x: number; y: number }) {
+  const store = useChargesStore()
+  const charges = store.charges
+
+  // eslint-disable-next-line
+  let netField = { x: 0, y: 0 }
+
+  charges.forEach(charge => {
+    const field = calculateElectricField(
+      charge.position,
+      charge.magnitude,
+      point,
+      charge.polarity === 'positive'
+    )
+    netField.x += field.x
+    netField.y += field.y
+  })
+
+  return netField
 }


### PR DESCRIPTION
### Summary

This PR implements live electric field readouts at the cursor position within the canvas, enhancing the user’s ability to analyze dynamic field behavior precisely and intuitively.

Closes #64 

---

### ✅ Features Implemented

- **Live electric field vector display** (`Ex`, `Ey`) in the bottom-right corner of the canvas.
- Field values update in real-time as the user moves the mouse across the canvas.
- Scaled values are shown in **kN/C** for readability.
- Inverted Y-component (`Ey`) to match the visual direction of field vectors.
- Minimal performance overhead using direct DOM interaction and reactive updates.

---

### 🧩 Technical Details

- Added a new utility: `getNetElectricFieldAtPoint` in `mathUtils.ts` to aggregate total field from all charges.
- Registered a `mousemove` listener in `PixiCanvas.vue` to capture cursor position and compute field values.
- Rendered a visually unobtrusive `.field-readout` overlay in the UI corner.
- Applied value scaling (`/ 1e3`) to convert from raw N/C to **kN/C**.

---

### 📸 Screenshots

<img width="1710" alt="Screenshot 2025-03-22 at 18 11 18" src="https://github.com/user-attachments/assets/2ec8c5c0-801c-465d-a59b-5f6461f5813f" />


### 🧪 Tested On

- Chrome, Firefox, Safari (desktop)
- Varying charge magnitudes and positions
- Edge cases like overlapping or near-zero field zones

---

### 📝 Notes

- Currently implemented for **electric mode** only.
- Magnetic field/vector readouts could follow a similar pattern in a future enhancement.
