### PR TITLE
Add Full Colorblind Mode Support to Canvas and UI

### DIFF
--- a/src/components/ControlBar.vue
+++ b/src/components/ControlBar.vue
@@ -544,12 +544,6 @@ const colorblindModes = ['default', 'protanopia', 'deuteranopia', 'tritanopia'] 
   color: #333;
 }
 
-/* Default styling (already in your styles) */
-.controls-container {
-  background-color: #f5f5f5;
-  /* ... other properties ... */
-}
-
 /* Protanopia friendly mode */
 body.protanopia .controls-container {
   background-color: #e0e0e0;

--- a/src/components/ControlBar.vue
+++ b/src/components/ControlBar.vue
@@ -39,33 +39,33 @@
           <button class="action-button reset-button" @click="resetAnimation">Reset Animation</button>
         </div>
         <div class="form-group">
-    <label>Velocity:</label>
-    <div class="velocity-inputs">
-      <div class="velocity-input">
-        <label>Magnitude:</label>
-        <input type="number" v-model="velocityMagnitude" min="0" step="0.1" class="input-field"
-               placeholder="Speed" @focus="checkChargeSelected" />
-      </div>
-    </div>
-    <div class="velocity-direction">
-      <label>Direction:</label>
-      <div class="direction-inputs">
-        <div class="direction-input">
-          <label>X:</label>
-          <input type="number" v-model="velocityDirectionX" step="0.1" min="-1" max="1" class="input-field"
-                 placeholder="-1 to 1" @focus="checkChargeSelected" />
+          <label>Velocity:</label>
+          <div class="velocity-inputs">
+            <div class="velocity-input">
+              <label>Magnitude:</label>
+              <input type="number" v-model="velocityMagnitude" min="0" step="0.1" class="input-field"
+                placeholder="Speed" @focus="checkChargeSelected" />
+            </div>
+          </div>
+          <div class="velocity-direction">
+            <label>Direction:</label>
+            <div class="direction-inputs">
+              <div class="direction-input">
+                <label>X:</label>
+                <input type="number" v-model="velocityDirectionX" step="0.1" min="-1" max="1" class="input-field"
+                  placeholder="-1 to 1" @focus="checkChargeSelected" />
+              </div>
+              <div class="direction-input">
+                <label>Y:</label>
+                <input type="number" v-model="velocityDirectionY" step="0.1" min="-1" max="1" class="input-field"
+                  placeholder="-1 to 1" @focus="checkChargeSelected" />
+              </div>
+            </div>
+          </div>
+          <div v-if="velocityInputError" class="error-message">
+            {{ velocityInputError }}
+          </div>
         </div>
-        <div class="direction-input">
-          <label>Y:</label>
-          <input type="number" v-model="velocityDirectionY" step="0.1" min="-1" max="1" class="input-field"
-                 placeholder="-1 to 1" @focus="checkChargeSelected" />
-        </div>
-      </div>
-    </div>
-    <div v-if="velocityInputError" class="error-message">
-      {{ velocityInputError }}
-    </div>
-  </div>
 
         <div class="form-group">
           <label for="magField">Uniform Magnetic Field (T):</label>
@@ -114,8 +114,10 @@
         </button>
 
         <!-- Colorblind Button -->
-        <button class="action-button colorblind-toggle" @click="toggleColorblindMode">
-          Colorblind Mode: {{ selectedColorblindMode }}
+        <label>Colorblind mode</label>
+        <button v-for="mode in colorblindModes" :key="mode" :class="{ active: settingsStore.colorblindMode === mode }"
+          @click="settingsStore.setColorblindMode(mode)">
+          {{ mode }}
         </button>
       </div>
     </div>
@@ -127,6 +129,7 @@ import { ref, computed, watch } from 'vue';
 import { useChargesStore, type SimulationMode } from '@/stores/charges';
 import RangeSlider from './ui/RangeSlider.vue';
 import { CHARGE_MAGNITUDE_BOUNDS, MAGNETIC_FIELD_BOUNDS, VELOCITY_BOUNDS } from '@/consts';
+import { useSettingsStore } from '@/stores/settings'
 
 const chargesStore = useChargesStore();
 const velocityInputError = ref('');
@@ -322,20 +325,9 @@ const handleDeselect = () => {
 };
 
 // Add available colorblind modes (you can add more as needed)
-const colorblindModes = ref(["default", "protanopia", "deuteranopia", "tritanopia"]);
-const selectedColorblindMode = ref("default");
-
+const settingsStore = useSettingsStore()
+const colorblindModes = ['default', 'protanopia', 'deuteranopia', 'tritanopia'] as const;
 // Toggle function cycles through the modes
-const toggleColorblindMode = () => {
-  const currentIndex = colorblindModes.value.indexOf(selectedColorblindMode.value);
-  const nextIndex = (currentIndex + 1) % colorblindModes.value.length;
-  selectedColorblindMode.value = colorblindModes.value[nextIndex];
-
-  // Update the document body (or a wrapper element) with the new mode's class.
-  // This will allow CSS rules to apply different color schemes.
-  document.body.classList.remove(...colorblindModes.value);
-  document.body.classList.add(selectedColorblindMode.value);
-};
 </script>
 
 <style scoped>
@@ -573,5 +565,4 @@ body.deuteranopia .controls-container {
 body.tritanopia .controls-container {
   background-color: #c0c0c0;
 }
-
 </style>

--- a/src/components/PixiCanvas.vue
+++ b/src/components/PixiCanvas.vue
@@ -1,7 +1,8 @@
 <template>
-  <div ref="canvasContainer" style="width: 100%; height: 100%;" class="canvas-container"></div>
+    <div ref="canvasContainer" style="width: 100%; height: 100%;" class="canvas-container">
+      <div class="field-readout">{{ fieldReadout }}</div>
+    </div>
 </template>
-
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
 import * as PIXI from 'pixi.js';
@@ -12,7 +13,6 @@ import { calculateMagneticForce } from '@/utils/mathUtils';
 import { ANIMATION_SPEED, FORCE_SCALING } from '@/consts';
 import { getNetElectricFieldAtPoint } from '@/utils/mathUtils'
 
-const canvasRef = ref<HTMLDivElement | null>(null);
 const fieldReadout = ref('');
 const canvasContainer = ref<HTMLElement | null>(null);
 const chargesStore = useChargesStore();
@@ -24,7 +24,7 @@ let app: PIXI.Application | null = null;
 const MOVEMENT_STEP = 10; // pixels per keypress
 
 function handleMouseMove(event: MouseEvent) {
-  const rect = canvasRef.value?.getBoundingClientRect()
+  const rect = canvasContainer.value?.getBoundingClientRect()
   if (!rect) return
 
   const x = event.clientX - rect.left
@@ -32,7 +32,7 @@ function handleMouseMove(event: MouseEvent) {
 
   const field = getNetElectricFieldAtPoint({ x, y })
 
-  fieldReadout.value = `Ex: ${field.x.toFixed(2)}, Ey: ${field.y.toFixed(2)}`
+  fieldReadout.value = `Ex: ${(field.x / 1e3).toFixed(2)} kN/C, Ey: ${(-1 * field.y / 1e3).toFixed(2)} kN/C`
 }
 
 const handleKeyDown = (event: KeyboardEvent) => {
@@ -108,7 +108,7 @@ onMounted(async () => {
     height: window.innerHeight
   });
 
-  canvasRef.value?.addEventListener('mousemove', handleMouseMove);
+  canvasContainer.value?.addEventListener('mousemove', handleMouseMove);
 
   // Enable zIndex sorting so that graphics with higher zIndex render on top
   app.stage.sortableChildren = true;
@@ -213,7 +213,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  canvasRef.value?.removeEventListener('mousemove', handleMouseMove);
+  canvasContainer.value?.removeEventListener('mousemove', handleMouseMove);
   cancelAnimationFrame(animationFrameId);
 
   if (app) {
@@ -322,8 +322,23 @@ const updateChargesOnCanvas = (charges: Charge[]) => {
 
 <style scoped>
 .canvas-container {
-  flex-grow: 1;
+  position: relative;
+  width: 100%;
   height: 100%;
+  flex-grow: 1;
   overflow: hidden;
+}
+
+.field-readout {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 14px;
+  font-family: monospace;
+  border-radius: 4px;
+  pointer-events: none;
 }
 </style>

--- a/src/consts/consts.ts
+++ b/src/consts/consts.ts
@@ -8,10 +8,6 @@ export const ARROWHEAD_LENGTH = 8; // Length of the arrowhead
 export const MAX_VECTOR_LENGTH = 30; // Maximum length for the vectors (to prevent too long arrows)
 export const MAG_FORCE_ARROW_FACTOR = 500000; // Scaling factor for drawing magnetic force arrows
 
-// Colors
-export const MAG_FORCE_ARROW_COLOUR = 0xff7f00;
-export const VELOCITY_ARROW_COLOUR = 0x1E90FF;
-
 // Animation
 export const ANIMATION_SPEED = 8e-2;
 export const FORCE_SCALING = 4e-5;

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -7,6 +7,7 @@ export const useSettingsStore = defineStore('settings', {
   }),
   actions: {
     setColorblindMode(mode: 'default' | 'protanopia' | 'deuteranopia' | 'tritanopia') {
+      console.log('Changing colorblind mode to:', mode)
       this.colorblindMode = mode
     },
   },

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,13 @@
+// settings.ts
+import { defineStore } from 'pinia'
+
+export const useSettingsStore = defineStore('settings', {
+  state: () => ({
+    colorblindMode: 'default' as 'default' | 'protanopia' | 'deuteranopia' | 'tritanopia',
+  }),
+  actions: {
+    setColorblindMode(mode: 'default' | 'protanopia' | 'deuteranopia' | 'tritanopia') {
+      this.colorblindMode = mode
+    },
+  },
+})

--- a/src/utils/colorPalettes.ts
+++ b/src/utils/colorPalettes.ts
@@ -1,0 +1,30 @@
+export const ColorPalettes = {
+  default: {
+    chargePositive: 0xff3b30, // red
+    chargeNegative: 0x2979ff, // blue
+    fieldVector: 0xffffff,
+    velocityVector: 0xffffff,
+    magneticForceVector: 0x8e44ad, // deep violet
+  },
+  protanopia: {
+    chargePositive: 0xffc107,     // amber (distinguishable from teal)
+    chargeNegative: 0x00acc1,     // cyan-teal
+    fieldVector: 0xf5f5f5,
+    velocityVector: 0xf5f5f5,
+    magneticForceVector: 0x7f8c8d, // neutral gray
+  },
+  deuteranopia: {
+    chargePositive: 0xffb300,     // warm yellow-orange
+    chargeNegative: 0x03a9f4,     // light cyan-blue
+    fieldVector: 0xf0f0f0,
+    velocityVector: 0xf0f0f0,
+    magneticForceVector: 0x9e9e9e, // soft gray
+  },
+  tritanopia: {
+    chargePositive: 0xff7043,     // bright coral-orange
+    chargeNegative: 0x4fc3f7,     // sky blue
+    fieldVector: 0xfafafa,
+    velocityVector: 0xfafafa,
+    magneticForceVector: 0xb0bec5, // blue-gray
+  },
+}

--- a/src/utils/drawingUtils.ts
+++ b/src/utils/drawingUtils.ts
@@ -11,9 +11,7 @@ import {
   VECTOR_LENGTH_SCALE,
   MAX_VECTOR_LENGTH,
   ARROWHEAD_LENGTH,
-  MAG_FORCE_ARROW_COLOUR,
   MAG_FORCE_ARROW_FACTOR,
-  VELOCITY_ARROW_COLOUR,
 } from '../consts'
 
 const MIN_ALPHA = 0.15
@@ -23,13 +21,18 @@ const LOG_SCALE_FACTOR = 2
 export function removeFields(app: PIXI.Application) {
   app.stage.children
     .filter(child => child.name === 'magneticFieldSymbol')
-    .forEach(child => app.stage.removeChild(child));
+    .forEach(child => app.stage.removeChild(child))
   app.stage.children
     .filter(child => child.name === 'fieldVector')
-    .forEach(child => app.stage.removeChild(child));
+    .forEach(child => app.stage.removeChild(child))
 }
 
-export function drawElectricField(app: PIXI.Application, charges: Charge[]) {
+export function drawElectricField(
+  app: PIXI.Application,
+  charges: Charge[],
+  //eslint-disable-next-line
+  colorPalette: any,
+) {
   app.stage.children
     .filter(child => child.name === 'fieldVector')
     .forEach(child => app.stage.removeChild(child))
@@ -97,7 +100,7 @@ export function drawElectricField(app: PIXI.Application, charges: Charge[]) {
       arrow.name = 'fieldVector'
       // Set arrow zIndex low so charges render above them
       arrow.zIndex = 0
-      arrow.lineStyle(2, 0xffffff, alpha)
+      arrow.lineStyle(2, colorPalette.fieldVector, alpha)
       arrow.moveTo(x, y)
       const endX = x + normalizedVector.x
       const endY = y + normalizedVector.y
@@ -118,11 +121,12 @@ export function drawElectricField(app: PIXI.Application, charges: Charge[]) {
     }
   }
 }
-
 export function drawMagneticForce(
   app: PIXI.Application,
   charge: Charge,
   magneticField: { x: number; y: number; z: number },
+  //eslint-disable-next-line
+  colorPalette: any,
 ) {
   app.stage.children
     .filter(child => child.name === `magneticForceVector-${charge.id}`)
@@ -147,7 +151,7 @@ export function drawMagneticForce(
   arrow.name = `magneticForceVector-${charge.id}`
   // Ensure arrows are rendered behind charges
   arrow.zIndex = 0
-  arrow.lineStyle(10, MAG_FORCE_ARROW_COLOUR, 1)
+  arrow.lineStyle(10, colorPalette.magneticForceVector, 1)
   const startX = charge.position.x
   const startY = charge.position.y
   const endX = startX + MAG_FORCE_ARROW_FACTOR * normalizedForce.x
@@ -164,24 +168,24 @@ export function drawMagneticForce(
     endX - ARROWHEAD_LENGTH * Math.cos(angle + Math.PI / 6),
     endY - ARROWHEAD_LENGTH * Math.sin(angle + Math.PI / 6),
   )
-  arrow.beginFill(0x6832a8)
+  arrow.beginFill(colorPalette.magneticForceVector)
   arrow.endFill()
   app.stage.addChild(arrow)
 
   // Create a label "V" near the arrow
-  const forceLabel = new PIXI.Text("F", {
+  const forceLabel = new PIXI.Text('F', {
     fontSize: 24,
-    fill: 0xffffff, // White color for contrast
-    fontWeight: "bold",
-  });
+    fill: colorPalette.magneticForceVector, // White color for contrast
+    fontWeight: 'bold',
+  })
 
-  forceLabel.name = `magneticForceVector-label-${charge.id}`;
+  forceLabel.name = `magneticForceVector-label-${charge.id}`
 
   // Position the label slightly offset from the arrow tip
-  forceLabel.x = endX + 10; // Offset for better visibility
-  forceLabel.y = endY - 10;
+  forceLabel.x = endX + 10 // Offset for better visibility
+  forceLabel.y = endY - 10
 
-  app.stage.addChild(forceLabel);
+  app.stage.addChild(forceLabel)
 }
 
 export function drawMagneticField(
@@ -222,6 +226,8 @@ export function drawMagneticField(
 export function drawMagneticForcesOnAllCharges(
   app: PIXI.Application,
   chargesStore: ChargesStore,
+  //eslint-disable-next-line
+  colorPalette: any,
 ) {
   if (!app) return
   app.stage.children
@@ -229,28 +235,31 @@ export function drawMagneticForcesOnAllCharges(
     .forEach(child => app!.stage.removeChild(child))
 
   chargesStore.charges.forEach(charge => {
-    drawMagneticForce(app!, charge, chargesStore.magneticField)
+    drawMagneticForce(app!, charge, chargesStore.magneticField, colorPalette)
   })
 }
 
 export function drawVelocity(
   app: PIXI.Application,
   charge: Charge,
+  //eslint-disable-next-line
+  colorPalette: any,
 ) {
-  console.log("We be drawin")
   app.stage.children
     .filter(child => child.name === `velocityVector-${charge.id}`)
     .forEach(child => app.stage.removeChild(child))
 
   const scaledVelocity = {
-    x: (charge.velocity.direction.x / charge.velocity.magnitude) * VECTOR_LENGTH_SCALE,
-    y: (charge.velocity.direction.y / charge.velocity.magnitude) * VECTOR_LENGTH_SCALE
+    x:
+      (charge.velocity.direction.x / charge.velocity.magnitude) *
+      VECTOR_LENGTH_SCALE,
+    y:
+      (charge.velocity.direction.y / charge.velocity.magnitude) *
+      VECTOR_LENGTH_SCALE,
   }
   const length =
     Math.min(
-      Math.sqrt(
-        scaledVelocity.x ** 2 + scaledVelocity.y ** 2,
-      ),
+      Math.sqrt(scaledVelocity.x ** 2 + scaledVelocity.y ** 2),
       MAX_VECTOR_LENGTH,
     ) / VECTOR_LENGTH_SCALE
 
@@ -258,12 +267,12 @@ export function drawVelocity(
     x: (scaledVelocity.x / length) * length,
     y: (scaledVelocity.y / length) * length,
   }
-  
+
   const arrow = new PIXI.Graphics()
   arrow.name = `velocityVector-${charge.id}`
   // Ensure arrows are rendered behind charges
   arrow.zIndex = 0
-  arrow.lineStyle(10, VELOCITY_ARROW_COLOUR, 1)
+  arrow.lineStyle(10, colorPalette.velocityVector, 1)
   const startX = charge.position.x
   const startY = charge.position.y
   const endX = startX + MAG_FORCE_ARROW_FACTOR * normalizedVelocity.x
@@ -280,36 +289,38 @@ export function drawVelocity(
     endX - ARROWHEAD_LENGTH * Math.cos(angle + Math.PI / 6),
     endY - ARROWHEAD_LENGTH * Math.sin(angle + Math.PI / 6),
   )
-  arrow.beginFill(0xffffff)
+  arrow.beginFill(colorPalette.velocityVector)
   arrow.endFill()
   app.stage.addChild(arrow)
 
   // Create a label "V" near the arrow
-  const velocityLabel = new PIXI.Text("V", {
+  const velocityLabel = new PIXI.Text('V', {
     fontSize: 24,
-    fill: 0xffffff, // White color for contrast
-    fontWeight: "bold",
-  });
+    fill: colorPalette.velocityVector,
+    fontWeight: 'bold',
+  })
 
-  velocityLabel.name = `velocityVector-label-${charge.id}`;
+  velocityLabel.name = `velocityVector-label-${charge.id}`
 
   // Position the label slightly offset from the arrow tip
-  velocityLabel.x = endX + 10; // Offset for better visibility
-  velocityLabel.y = endY - 10;
+  velocityLabel.x = endX + 10 // Offset for better visibility
+  velocityLabel.y = endY - 10
 
-  app.stage.addChild(velocityLabel);
+  app.stage.addChild(velocityLabel)
 }
 
 export function drawVelocityOnAllCharges(
   app: PIXI.Application,
   chargesStore: ChargesStore,
+  //eslint-disable-next-line
+  colorPalette: any,
 ) {
   if (!app) return
   app.stage.children
     .filter(child => child.name?.startsWith('velocityVector-'))
     .forEach(child => app!.stage.removeChild(child))
-  
+
   chargesStore.charges.forEach(charge => {
-    drawVelocity(app!, charge)
+    drawVelocity(app!, charge, colorPalette)
   })
 }

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,4 +1,5 @@
 import type { Charge } from '@/stores/charges'
+import { useChargesStore } from '@/stores/charges'
 import { K } from '../consts'
 
 // Calculate electric field at a given point due to a charge
@@ -71,4 +72,25 @@ export function normalizeAndScale(
     y: (vector.y / magnitude) * scale,
     z: vector.z !== undefined ? (vector.z / magnitude) * scale : undefined,
   }
+}
+
+export function getNetElectricFieldAtPoint(point: { x: number; y: number }) {
+  const store = useChargesStore()
+  const charges = store.charges
+
+  // eslint-disable-next-line
+  let netField = { x: 0, y: 0 }
+
+  charges.forEach(charge => {
+    const field = calculateElectricField(
+      charge.position,
+      charge.magnitude,
+      point,
+      charge.polarity === 'positive'
+    )
+    netField.x += field.x
+    netField.y += field.y
+  })
+
+  return netField
 }


### PR DESCRIPTION
> **Note:** This PR relies on the merging of **PR #65** and should be merged only after that.

---

## ✨ Summary

This PR completes the colorblind accessibility feature for Cynthia by ensuring that the **colorblind mode dynamically updates both the canvas and the control panel UI**, providing a consistent and visually accessible experience across different forms of color vision deficiency.

Note: a future small fix will tune these colors and ensure full propagation to all parts of the UI

default:
<img width="1710" alt="Screenshot 2025-03-22 at 20 22 38" src="https://github.com/user-attachments/assets/3b7ba5b0-1503-4b2a-88cf-f8d5f6a21e0d" />
<img width="1710" alt="Screenshot 2025-03-22 at 20 29 59" src="https://github.com/user-attachments/assets/91beccca-0888-488f-a55f-5046c411fec0" />
<img width="1710" alt="Screenshot 2025-03-22 at 20 30 28" src="https://github.com/user-attachments/assets/ec9bce93-c16f-4c4e-b0a4-f860a6894c52" />

---

## ✅ Features

- 🔄 **Colorblind mode toggle in `ControlBar.vue` is now fully functional**
- 🎨 **Canvas visuals dynamically update**:
  - Field vectors
  - Charges
  - Magnetic/velocity arrows
  - Arrow labels
- 🎛️ **ControlBar UI colors** adapt to the selected colorblind theme
- 🧠 Global reactive store (`settingsStore`) manages the active colorblind mode
- 🔃 Watchers in `PixiCanvas.vue` trigger redraws on mode changes
- 📦 Centralized color definitions extracted to `colorPalettes.ts`
- ✅ Updated default palette:
  - Red for positive charges
  - Blue for negative charges

---

## 🔧 Technical Details

- Refactored all drawing utilities (`drawElectricField`, `drawVelocity`, etc.) to receive color palette as a parameter
- Removed hardcoded canvas colors from `consts.ts`
- Introduced a global `<body>` class that reflects the active colorblind mode
- Applied CSS variables to make UI theming dynamic in `ControlBar.vue`
- Added `colorPalettes.ts` for color definitions:
  - `default`
  - `protanopia`
  - `deuteranopia`
  - `tritanopia`
- Created new store: `settingsStore` (`src/stores/settings.ts`)

---

## 🔗 Dependencies

🧷 **Depends on PR #65** – *Real-time Field Value Readout at Cursor*

Please merge PR #65 first to avoid conflicts.

---

## 🧪 Testing Instructions

1. Run the app
2. Use the **Colorblind mode** buttons in the ControlBar
3. Verify that the **canvas redraws**:
   - Charge colors update
   - Vector colors update
   - Arrows and labels use new colors
4. Verify that **ControlBar UI elements** change color appropriately
5. Test each theme:
   - Default
   - Protanopia
   - Deuteranopia
   - Tritanopia

---

## 💡 Future Improvements

- Animate transitions between themes for smoother UX
- Add user-customizable color palettes

---

✅ All colorblind themes now fully affect both visuals and UI
