### PR TITLE
Fix the side bar getting cut off + charge and vector sizes for diff screen size

### DIFF
--- a/src/components/ControlBar.vue
+++ b/src/components/ControlBar.vue
@@ -924,4 +924,54 @@ body.dark-mode .delete-button {
 body.dark-mode .delete-button:hover:not(:disabled) {
   background-color: #a93226;
 }
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .controls-container {
+    width: 100%;
+    min-width: unset;
+    padding: 10px 15px 10px 10px; /* extra right padding */
+    max-height: 100vh;
+    overflow-y: auto; /* Vertical scroll if needed */
+    overflow-x: auto; /* Allow horizontal scroll if absolutely necessary */
+    box-sizing: border-box; /* Ensure padding is included in the width */
+  }
+
+  .header-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .logo {
+    font-size: 20px;
+  }
+
+  .outlined-icon-button {
+    padding: 4px 6px;
+    font-size: 0.8rem;
+  }
+
+  .charge-form {
+    padding: 10px;
+  }
+
+  .input-field {
+    padding: 6px;
+    font-size: 0.9rem;
+  }
+
+  .mode-toggle {
+    margin-bottom: 16px;
+  }
+
+  /* Ensure text wraps correctly */
+  .selection-controls,
+  .settings-modal,
+  .form-group {
+    overflow-wrap: break-word;
+  }
+}
+
+
 </style>

--- a/src/components/PixiCanvas.vue
+++ b/src/components/PixiCanvas.vue
@@ -111,12 +111,13 @@ const updateChargeTrail = (charge: Charge, trailGraphics: PIXI.Graphics) => {
   if (!charge.trail) {
     charge.trail = [];
   }
+  const scaleFactor = window.innerWidth < 600 ? 0.6 : 1.0;
 
   if (charge.trailSampleCounter === undefined) {
     charge.trailSampleCounter = 0;
   }
 
-  const minDistance = 25; // Minimum distance traveled before taking a sample
+  const minDistance = 25 * scaleFactor; // Minimum distance traveled before taking a sample
 
   // Calculate distance from last sampled position
   if (charge.trail.length === 0 ||
@@ -133,7 +134,7 @@ const updateChargeTrail = (charge: Charge, trailGraphics: PIXI.Graphics) => {
   trailGraphics.clear();
 
   // Option 1: Draw small dots along the trail
-  const dotRadius = 8;
+  const dotRadius = 8 * scaleFactor;
   trailGraphics.beginFill(0xffffff, 0.7);
   for (const pos of charge.trail) {
     trailGraphics.drawCircle(pos.x, pos.y, dotRadius);
@@ -352,6 +353,8 @@ const resize = () => {
 const updateChargesOnCanvas = (charges: Charge[]) => {
   if (!app) return;
 
+  const scaleFactor = window.innerWidth < 600 ? 0.6 : 1.0;
+
   // Remove graphics for charges that no longer exist
   for (const [id, graphic] of chargesGraphics) {
     if (!charges.find((charge) => charge.id === id)) {
@@ -401,7 +404,7 @@ const updateChargesOnCanvas = (charges: Charge[]) => {
     const polarity = charge.polarity === 'positive' ? "+" : "-";
 
     // Draw the charge circle
-    const radius = 24
+    const radius = 24 * scaleFactor;
     graphic.beginFill(color);
     // graphic.lineStyle(0);
     graphic.drawCircle(0, 0, radius);
@@ -416,7 +419,7 @@ const updateChargesOnCanvas = (charges: Charge[]) => {
       const labelText = `${polarity}${charge.magnitude}C`;
       text = new PIXI.Text(labelText, {
         fontFamily: settingsStore.dyslexiaMode ? 'OpenDyslexic' : 'Poppins',
-        fontSize: 16,
+        fontSize: 16 * scaleFactor,
         fill: palette.value.chargeText,
         align: 'center',
       });
@@ -428,6 +431,7 @@ const updateChargesOnCanvas = (charges: Charge[]) => {
     } else {
       text.text = polarity + charge.magnitude.toString() + 'C';
       text.style.fontFamily = settingsStore.dyslexiaMode ? 'OpenDyslexic' : 'Poppins';
+      text.style.fontSize = 16 * scaleFactor;
     }
 
     text.anchor.set(0.5);

--- a/src/utils/drawingUtils.ts
+++ b/src/utils/drawingUtils.ts
@@ -118,22 +118,26 @@ export function drawMagneticForce(
   charge: Charge,
   magneticField: { x: number; y: number; z: number },
   //eslint-disable-next-line
-  colorPalette: any,
+  colorPalette: any
 ) {
+  const scaleFactor = app.screen.width < 900 ? 0.6 : 1.0;
+  // Remove any existing magnetic force vectors for this charge
   app.stage.children
     .filter(child => child.name === `magneticForceVector-${charge.id}`)
     .forEach(child => app.stage.removeChild(child))
 
   const magneticForce = calculateMagneticForce(charge, magneticField)
   const scaledForce = normalizeAndScale(magneticForce, VECTOR_LENGTH_SCALE)
-  const length =
-    Math.min(
-      Math.sqrt(
-        scaledForce.x ** 2 + scaledForce.y ** 2 + (scaledForce.z || 0) ** 2,
-      ),
-      MAX_VECTOR_LENGTH,
-    ) / VECTOR_LENGTH_SCALE
+  
+  // Calculate the length and then adjust it by the scale factor.
+  const length = Math.min(
+    Math.sqrt(
+      scaledForce.x ** 2 + scaledForce.y ** 2 + (scaledForce.z || 0) ** 2,
+    ),
+    MAX_VECTOR_LENGTH
+  ) / VECTOR_LENGTH_SCALE * scaleFactor
 
+  // Normalize the force using the scaled length
   const normalizedForce = {
     x: (scaledForce.x / length) * length,
     y: (scaledForce.y / length) * length,
@@ -141,41 +145,46 @@ export function drawMagneticForce(
 
   const arrow = new PIXI.Graphics()
   arrow.name = `magneticForceVector-${charge.id}`
-  // Ensure arrows are rendered behind charges
   arrow.zIndex = 0
-  arrow.lineStyle(10, colorPalette.magneticForceVector, 1)
+  
+  // Scale the line thickness by the scale factor.
+  arrow.lineStyle(10 * scaleFactor, colorPalette.magneticForceVector, 1)
+
   const startX = charge.position.x
   const startY = charge.position.y
-  const endX = startX + MAG_FORCE_ARROW_FACTOR * normalizedForce.x
-  const endY = startY + MAG_FORCE_ARROW_FACTOR * normalizedForce.y
+  // Apply scale factor to the arrow's length offset
+  const endX = startX + MAG_FORCE_ARROW_FACTOR * normalizedForce.x * scaleFactor
+  const endY = startY + MAG_FORCE_ARROW_FACTOR * normalizedForce.y * scaleFactor
+
   arrow.moveTo(startX, startY)
   arrow.lineTo(endX, endY)
+
   const angle = Math.atan2(normalizedForce.y, normalizedForce.x)
+  // Multiply ARROWHEAD_LENGTH by scaleFactor so arrowheads are appropriately sized
   arrow.lineTo(
-    endX - ARROWHEAD_LENGTH * Math.cos(angle - Math.PI / 6),
-    endY - ARROWHEAD_LENGTH * Math.sin(angle - Math.PI / 6),
+    endX - ARROWHEAD_LENGTH * scaleFactor * Math.cos(angle - Math.PI / 6),
+    endY - ARROWHEAD_LENGTH * scaleFactor * Math.sin(angle - Math.PI / 6)
   )
   arrow.moveTo(endX, endY)
   arrow.lineTo(
-    endX - ARROWHEAD_LENGTH * Math.cos(angle + Math.PI / 6),
-    endY - ARROWHEAD_LENGTH * Math.sin(angle + Math.PI / 6),
+    endX - ARROWHEAD_LENGTH * scaleFactor * Math.cos(angle + Math.PI / 6),
+    endY - ARROWHEAD_LENGTH * scaleFactor * Math.sin(angle + Math.PI / 6)
   )
   arrow.beginFill(colorPalette.magneticForceVector)
   arrow.endFill()
   app.stage.addChild(arrow)
 
-  // Create a label "V" near the arrow
+  // Create a label "F" near the arrow
   const forceLabel = new PIXI.Text('F', {
-    fontSize: 24,
-    fill: colorPalette.magneticForceVector, // White color for contrast
+    fontSize: 24 * scaleFactor, // Scale text size
+    fill: colorPalette.magneticForceVector,
     fontWeight: 'bold',
   })
 
   forceLabel.name = `magneticForceVector-label-${charge.id}`
-
-  // Position the label slightly offset from the arrow tip
-  forceLabel.x = endX + 10 // Offset for better visibility
-  forceLabel.y = endY - 10
+  // Offset the label by a value multiplied by scaleFactor
+  forceLabel.x = endX + 10 * scaleFactor
+  forceLabel.y = endY - 10 * scaleFactor
 
   app.stage.addChild(forceLabel)
 }
@@ -237,6 +246,7 @@ export function drawVelocity(
   //eslint-disable-next-line
   colorPalette: any,
 ) {
+  const scaleFactor = app.screen.width < 900 ? 0.6 : 1.0;
   app.stage.children
     .filter(child => child.name === `velocityVector-${charge.id}`)
     .forEach(child => app.stage.removeChild(child))
@@ -249,10 +259,11 @@ export function drawVelocity(
       (charge.velocity.direction.y / charge.velocity.magnitude) *
       VECTOR_LENGTH_SCALE,
   }
+  // Multiply the computed length by scaleFactor
   const length = 0.5 * Math.min(
       Math.sqrt(scaledVelocity.x ** 2 + scaledVelocity.y ** 2),
       MAX_VECTOR_LENGTH,
-    ) / VECTOR_LENGTH_SCALE
+    ) / VECTOR_LENGTH_SCALE * scaleFactor
 
   const normalizedVelocity = {
     x: (scaledVelocity.x / length) * length,
@@ -261,24 +272,28 @@ export function drawVelocity(
 
   const arrow = new PIXI.Graphics()
   arrow.name = `velocityVector-${charge.id}`
-  // Ensure arrows are rendered behind charges
   arrow.zIndex = 0
-  arrow.lineStyle(10, colorPalette.velocityVector, 1)
+  
+  // Multiply line thickness by scaleFactor
+  arrow.lineStyle(10 * scaleFactor, colorPalette.velocityVector, 1)
+  
   const startX = charge.position.x
   const startY = charge.position.y
-  const endX = startX + MAG_FORCE_ARROW_FACTOR * normalizedVelocity.x
-  const endY = startY + MAG_FORCE_ARROW_FACTOR * normalizedVelocity.y
+  // Multiply the arrow's extension factor by scaleFactor
+  const endX = startX + MAG_FORCE_ARROW_FACTOR * normalizedVelocity.x * scaleFactor
+  const endY = startY + MAG_FORCE_ARROW_FACTOR * normalizedVelocity.y * scaleFactor
+
   arrow.moveTo(startX, startY)
   arrow.lineTo(endX, endY)
   const angle = Math.atan2(normalizedVelocity.y, normalizedVelocity.x)
   arrow.lineTo(
-    endX - ARROWHEAD_LENGTH * Math.cos(angle - Math.PI / 6),
-    endY - ARROWHEAD_LENGTH * Math.sin(angle - Math.PI / 6),
+    endX - ARROWHEAD_LENGTH * scaleFactor * Math.cos(angle - Math.PI / 6),
+    endY - ARROWHEAD_LENGTH * scaleFactor * Math.sin(angle - Math.PI / 6)
   )
   arrow.moveTo(endX, endY)
   arrow.lineTo(
-    endX - ARROWHEAD_LENGTH * Math.cos(angle + Math.PI / 6),
-    endY - ARROWHEAD_LENGTH * Math.sin(angle + Math.PI / 6),
+    endX - ARROWHEAD_LENGTH * scaleFactor * Math.cos(angle + Math.PI / 6),
+    endY - ARROWHEAD_LENGTH * scaleFactor * Math.sin(angle + Math.PI / 6)
   )
   arrow.beginFill(colorPalette.velocityVector)
   arrow.endFill()
@@ -286,16 +301,15 @@ export function drawVelocity(
 
   // Create a label "V" near the arrow
   const velocityLabel = new PIXI.Text('V', {
-    fontSize: 24,
+    fontSize: 24 * scaleFactor, // Scale text size
     fill: colorPalette.velocityVector,
     fontWeight: 'bold',
   })
 
   velocityLabel.name = `velocityVector-label-${charge.id}`
-
-  // Position the label slightly offset from the arrow tip
-  velocityLabel.x = endX + 10 // Offset for better visibility
-  velocityLabel.y = endY - 10
+  // Multiply offset values by scaleFactor
+  velocityLabel.x = endX + 10 * scaleFactor
+  velocityLabel.y = endY - 10 * scaleFactor
 
   app.stage.addChild(velocityLabel)
 }


### PR DESCRIPTION
Side bar was getting cut off before. Charges and vector magnitude weren't adjusted for screen size. Fixed in this PR but did not fix fields because I don't know how tbh lol

Computer:
![Screenshot from 2025-03-23 21-03-28](https://github.com/user-attachments/assets/e937170b-f58f-485e-b9f5-297230f92a77)

Ipad: 
![ipad3](https://github.com/user-attachments/assets/b1f89841-9fd1-44c8-96ce-1b7390f8c1bf)


Iphone:
![iphone3](https://github.com/user-attachments/assets/ac18322e-4c8a-42dd-9484-9c66db72cb5a)
![Screenshot from 2025-03-23 21-10-19](https://github.com/user-attachments/assets/a221b8f8-f548-4d00-aae9-a413f965342e)


