### PR TITLE
updated partial forces for distinction between charges inducing the f…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,8 +21,6 @@
     <!-- Main canvas area -->
     <PixiCanvas />
 
-    <ControlBar :key="controlBarKey" />
-
     <!-- Toggle Tab Button -->
     <button @click="drawerOpen = !drawerOpen" class="absolute z-30 right-0 top-1/2 -translate-y-1/2 translate-x-1/2
        w-10 h-12 bg-gray-900 hover:bg-gray-800 text-white shadow-lg
@@ -49,7 +47,7 @@
     <transition name="slide">
       <div v-show="drawerOpen"
         class="w-[320px] h-full bg-white shadow-lg z-10 transition-transform duration-300 ease-in-out">
-        <ControlBar />
+        <ControlBar :key="controlBarKey" />
       </div>
     </transition>
   </div>


### PR DESCRIPTION
### Description
Addressing Son's comment in the previous PR where he mentioned that we should be able to distinguish what forces are induced by which charges. I didn't want to use different colors because that would mean more colors for more charges and that could make things confusing. So as of right now, partial forces are all in blue and total forces in red. When you hover over a charge, its associated partial forces on other charges are slightly highlighted. I will probably add a little box with some explanations for this force display mode as it may not be 100% intuitive to first time users.

### Features Added
**1. Improved Force Arrow Visualization**

- Distinct styling for total forces (red) vs partial forces (blue)
- Visual hierarchy with total forces drawn thicker (3px) than partial forces (2px)
- Semi-transparent partial forces (50% opacity) to reduce visual clutter
- Force labeling system that assigns simple identifiers (C1, C2, etc.) to each charge
- Small indicators on partial force vectors showing which charge is causing each force

**2. Interactive Highlighting**

- Hovering over a charge highlights all partial forces exerted by that charge
- Total forces (red) remain clearly visible at all times
- Labels and indicators maintain consistent visibility with their associated force arrows

Force vectors and their labels are set to be non-interactive to prevent them from interfering with charge selection while still allowing visual highlighting effects when hovering over charges.

NOTE: THERE IS A LITTLE BUG WHERE SELECTING CHARGES DOESN'T WORK SOME TIMES. I WILL HAVE A LOOK AT THAT NEXT AND TRY TO FIX IT.

![image](https://github.com/user-attachments/assets/c07d68f8-f77a-4b59-b57f-38ed0d0a412f)
