### PR TITLE
Get rid of scrolling on mobile.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Vite App</title>
   </head>
   <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,7 +57,13 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap');
 
-body {
+html {
+  overscroll-behavior: none;
+}
+
+html, body {
+  overflow: hidden;
+  height: 100%;
   margin: 0;
 }
 


### PR DESCRIPTION
On mobile, there is an issue where the user is able to scroll and hide the sidebar making it for a weird experience (seems like freezing). This change makes it so the user cannot scroll or zoom in on mobile, essentially saving them from themselves.