### PR TITLE
Prevent horizontal scroll, allow vertical

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,9 +62,11 @@ html {
 }
 
 html, body {
-  overflow: hidden;
+  overflow-x: hidden;   /* Prevent horizontal scrolling */
+  overflow-y: auto;     /* Allow vertical scrolling */
   height: 100%;
   margin: 0;
+  -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
 }
 
 #app {


### PR DESCRIPTION
Disabling vertical scroll prevented safari from removing url bar. This made it so some features in our control bar were blocked which wasn't good.